### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <apache.commons.langs.version>3.1</apache.commons.langs.version>
         <apache.commons.logging.version>1.1.1</apache.commons.logging.version>
         <apache.commons.fileupload.version>1.3.1</apache.commons.fileupload.version>
-        <apache.commons.collections.version>3.2.1</apache.commons.collections.version>
+        <apache.commons.collections.version>3.2.2</apache.commons.collections.version>
         <gsion.version>2.5</gsion.version>
         <junit.version>3.8.1</junit.version>
         <jstl.version>1.2</jstl.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
